### PR TITLE
Fix issues in MultipleTopicSubscriberTestCase

### DIFF
--- a/modules/broker-amqp/src/main/java/io/ballerina/messaging/broker/amqp/AmqpDeliverMessage.java
+++ b/modules/broker-amqp/src/main/java/io/ballerina/messaging/broker/amqp/AmqpDeliverMessage.java
@@ -23,6 +23,7 @@ import io.ballerina.messaging.broker.amqp.codec.AmqpChannel;
 import io.ballerina.messaging.broker.amqp.codec.frames.BasicDeliver;
 import io.ballerina.messaging.broker.amqp.codec.frames.ContentFrame;
 import io.ballerina.messaging.broker.amqp.codec.frames.HeaderFrame;
+import io.ballerina.messaging.broker.common.ResourceNotFoundException;
 import io.ballerina.messaging.broker.common.data.types.ShortString;
 import io.ballerina.messaging.broker.core.Broker;
 import io.ballerina.messaging.broker.core.BrokerException;
@@ -74,6 +75,9 @@ public class AmqpDeliverMessage {
                 broker.requeue(queueName, message);
             } catch (BrokerException e) {
                 LOGGER.error("Error while requeueing message {} for queue {}", message, queueName, e);
+            } catch (ResourceNotFoundException e) {
+                LOGGER.warn("Cannot requeue message [" + message + "] since queue [" + queueName + "] is not found",
+                            e);
             }
         } else if (!channel.isFlowEnabled()) {
             channel.hold(this);

--- a/modules/broker-amqp/src/main/java/io/ballerina/messaging/broker/amqp/codec/AmqpChannel.java
+++ b/modules/broker-amqp/src/main/java/io/ballerina/messaging/broker/amqp/codec/AmqpChannel.java
@@ -25,6 +25,7 @@ import io.ballerina.messaging.broker.amqp.AmqpDeliverMessage;
 import io.ballerina.messaging.broker.amqp.AmqpServerConfiguration;
 import io.ballerina.messaging.broker.amqp.codec.flow.ChannelFlowManager;
 import io.ballerina.messaging.broker.amqp.metrics.AmqpMetricManager;
+import io.ballerina.messaging.broker.common.ResourceNotFoundException;
 import io.ballerina.messaging.broker.common.ValidationException;
 import io.ballerina.messaging.broker.common.data.types.FieldTable;
 import io.ballerina.messaging.broker.common.data.types.ShortString;
@@ -204,6 +205,9 @@ public class AmqpChannel {
                 broker.requeue(queueName, message);
             } catch (BrokerException e) {
                 LOGGER.error("Error while requeueing message {} for queue ()", message, queueName, e);
+            } catch (ResourceNotFoundException e) {
+                LOGGER.warn("Cannot requeue message [" + message + "] since queue [" + queueName + "] is not found",
+                            e);
             }
         }
     }
@@ -267,7 +271,7 @@ public class AmqpChannel {
         unackedMessageMap.put(deliveryTag, ackData);
     }
 
-    public void reject(long deliveryTag, boolean requeue) throws BrokerException {
+    public void reject(long deliveryTag, boolean requeue) throws BrokerException, ResourceNotFoundException {
         metricManager.markReject();
         AckData ackData = unackedMessageMap.negativeAcknowledge(deliveryTag);
         if (MessageTracer.isTraceEnabled()) {
@@ -290,7 +294,8 @@ public class AmqpChannel {
         }
     }
 
-    private void setRedeliverAndRequeue(Message message, String queueName) throws BrokerException {
+    private void setRedeliverAndRequeue(Message message, String queueName)
+            throws BrokerException, ResourceNotFoundException {
         int redeliveryCount = message.setRedeliver();
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Redelivery count is {} for message {}",
@@ -316,7 +321,14 @@ public class AmqpChannel {
     public void requeueAll() throws BrokerException {
         Collection<AckData> entries = unackedMessageMap.removeAll();
         for (AckData ackData : entries) {
-            broker.requeue(ackData.getQueueName(), ackData.getMessage());
+            String queueName = ackData.getQueueName();
+            Message message = ackData.getMessage();
+            try {
+                broker.requeue(queueName, message);
+            } catch (ResourceNotFoundException e) {
+                LOGGER.warn("Cannot requeue message [" + message + "] since queue [" + queueName + "] is not found",
+                            e);
+            }
         }
     }
 

--- a/modules/broker-core/src/main/java/io/ballerina/messaging/broker/core/Broker.java
+++ b/modules/broker-core/src/main/java/io/ballerina/messaging/broker/core/Broker.java
@@ -487,10 +487,14 @@ public final class Broker {
         return messageIdGenerator.getNextId();
     }
 
-    public void requeue(String queueName, Message message) throws BrokerException {
+    public void requeue(String queueName, Message message) throws BrokerException, ResourceNotFoundException {
         lock.readLock().lock();
         try {
             QueueHandler queueHandler = queueRegistry.getQueueHandler(queueName);
+
+            if (Objects.isNull(queueHandler)) {
+                throw new ResourceNotFoundException("Queue [ " + queueName + " ] Not found");
+            }
             queueHandler.requeue(message);
         } finally {
             lock.readLock().unlock();

--- a/modules/integration/src/test/java/io/ballerina/messaging/broker/integration/standalone/jms/MultipleTopicSubscriberTestCase.java
+++ b/modules/integration/src/test/java/io/ballerina/messaging/broker/integration/standalone/jms/MultipleTopicSubscriberTestCase.java
@@ -61,7 +61,7 @@ public class MultipleTopicSubscriberTestCase {
         TopicConnection connection = connectionFactory.createTopicConnection();
         connection.start();
 
-        TopicSession subscriberSession = connection.createTopicSession(false, TopicSession.AUTO_ACKNOWLEDGE);
+        TopicSession subscriberSession = connection.createTopicSession(false, TopicSession.CLIENT_ACKNOWLEDGE);
         Topic topic = (Topic) initialContext.lookup(queueName);
 
         int numberOfConsumers = 3;
@@ -77,6 +77,11 @@ public class MultipleTopicSubscriberTestCase {
             int finalConsumerIndex = consumerIndex;
             consumers[consumerIndex].setMessageListener(message -> {
                 messageCount[finalConsumerIndex]++;
+                try {
+                    message.acknowledge();
+                } catch (JMSException e) {
+                    LOGGER.error("Message acknowledging failed.", e);
+                }
                 receiveQueue.offer(new MessageResult(message, finalConsumerIndex));
             });
         }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

In MultipleTopicSubscriberTestCase we have used a blocking queue to synchronize multiple consumers. But this can lead to threads getting synchronized before the message acknowledgment is sent. Therefore the test case was modified to use client acknowledgment and ack before signaling the message addition.

Additionally, we requeue unacked message when closing the channel, not when closing the consumer. Therefore there can be unacked messages belonging to auto-deleted queues when we close the channel. In this PR we have added a log to identify those scenarios.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Use client ack mode in the MultipleTopicSubscriberTestCase.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

Use client ack mode in the MultipleTopicSubscriberTestCase.

## User stories
> Summary of user stories addressed by this change>

N/A

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

N/A

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

N/A

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

N/A

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

N/A

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

N/A

## Automation tests
 - Unit tests - 78% 
 - Integration tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.