### PR TITLE
Change headers,properties fields' init in Metadata

### DIFF
--- a/modules/broker-core/src/main/java/io/ballerina/messaging/broker/core/Metadata.java
+++ b/modules/broker-core/src/main/java/io/ballerina/messaging/broker/core/Metadata.java
@@ -76,16 +76,16 @@ public class Metadata {
         this.routingKey = routingKey;
         this.exchangeName = exchangeName;
         this.contentLength = contentLength;
-        this.properties = FieldTable.EMPTY_TABLE;
-        this.headers = FieldTable.EMPTY_TABLE;
+        this.properties = new FieldTable();
+        this.headers = new FieldTable();
     }
 
     public Metadata(String routingKey, String exchangeName, long contentLength, byte[] propertyBytes) throws Exception {
         this.routingKey = routingKey;
         this.exchangeName = exchangeName;
         this.contentLength = contentLength;
-        this.properties = FieldTable.EMPTY_TABLE;
-        this.headers = FieldTable.EMPTY_TABLE;
+        this.properties = new FieldTable();
+        this.headers = new FieldTable();
         setPropertiesFromBytes(propertyBytes);
     }
 


### PR DESCRIPTION
Initializing the above fields to Empty_Table filels makes them unmodifiable.
Hence they should be initialized with a new FileldTable.