### PR TITLE
Update queue and exchange delete default behavior

### DIFF
--- a/docs/user/cli-client.md
+++ b/docs/user/cli-client.md
@@ -100,10 +100,10 @@ Result output format (--output, -o) (default: table) (allowed values: table, csv
 Exchanges can be deleted from the Broker using the CLI.
 
 #### Command format:
-`./broker-admin.sh delete exchange (exchange_name)? (--unused|-u)? (global_flags)*`
+`./broker-admin.sh delete exchange (exchange_name)? (--force-used|-u)? (global_flags)*`
 
 #### Options:
-Delete only if unused (--unused, -u) (default: false/not set by default) 
+Force delete exchange with bindings (--force-used, -u) (default: false/not set by default)
 
 #### Sample commands:
 Delete a specific exchange if its unused<br/>
@@ -156,14 +156,14 @@ Result output format (--output, -o) (default: table) (allowed values: table, csv
 Queues can be deleted from the Broker using the CLI.
 
 #### Command format:
-`./broker-admin.sh delete queue (queue_name)? (--unused|-u)? (--empty|-e)? (global_flags)*`
+`./broker-admin.sh delete queue (queue_name)? (--force-used|-u)? (--force-non-empty|-e)? (global_flags)*`
 
 #### Options:
-- Delete only if unused (--unused, -u) (default: false/not set by default)<br/> 
-- Delete only if empty (--empty, -e) (default: false/not set by default) 
+- Force delete queue with consumers (--force-used, -u) (default: false/not set by default)<br/>
+- Force delete non empty queue (--force-non-empty, -e) (default: false/not set by default)
 
 #### Sample commands:
-Delete a specific exchange if its unused<br/>
+Delete a specific exchange if it's unused<br/>
 `./broker-admin.sh delete exchange my_exchange -u`
 
 ## 4. Bindings related administrative operations

--- a/modules/broker-cli-client/src/main/java/io/ballerina/messaging/broker/client/cmd/impl/delete/DeleteExchangeCmd.java
+++ b/modules/broker-cli-client/src/main/java/io/ballerina/messaging/broker/client/cmd/impl/delete/DeleteExchangeCmd.java
@@ -44,9 +44,9 @@ public class DeleteExchangeCmd extends DeleteCmd {
                required = true)
     private String exchangeName;
 
-    @Parameter(names = { "--unused", "-u" },
-               description = "delete only if the exchange is not in use")
-    private boolean ifUnused = false;
+    @Parameter(names = { "--force-used", "-u" },
+               description = "force delete already in use exchange")
+    private boolean forceUsed = false;
 
     public DeleteExchangeCmd(String rootCommand) {
         super(rootCommand);
@@ -63,8 +63,8 @@ public class DeleteExchangeCmd extends DeleteCmd {
         HttpClient httpClient = new HttpClient(configuration);
         HttpRequest httpRequest = new HttpRequest(Constants.EXCHANGES_URL_PARAM + exchangeName);
 
-        if (ifUnused) {
-            httpRequest.setQueryParameters("?ifUnused=true");
+        if (forceUsed) {
+            httpRequest.setQueryParameters("?ifUnused=false");
         }
 
         // do DELETE

--- a/modules/broker-cli-client/src/main/java/io/ballerina/messaging/broker/client/cmd/impl/delete/DeleteQueueCmd.java
+++ b/modules/broker-cli-client/src/main/java/io/ballerina/messaging/broker/client/cmd/impl/delete/DeleteQueueCmd.java
@@ -44,13 +44,13 @@ public class DeleteQueueCmd extends DeleteCmd {
                required = true)
     private String queueName;
 
-    @Parameter(names = { "--unused", "-u" },
-               description = "delete only if the queue is not in use")
-    private boolean ifUnused = false;
+    @Parameter(names = { "--force-used", "-u" },
+               description = "force delete already in use queue")
+    private boolean forceUsed = false;
 
-    @Parameter(names = { "--empty", "-e" },
-               description = "delete only if the queue is empty")
-    private boolean ifEmpty = false;
+    @Parameter(names = { "--force-non-empty", "-e" },
+               description = "force delete non empty queue")
+    private boolean forceNonEmpty = false;
 
     public DeleteQueueCmd(String rootCommand) {
         super(rootCommand);
@@ -67,7 +67,8 @@ public class DeleteQueueCmd extends DeleteCmd {
         HttpClient httpClient = new HttpClient(configuration);
         HttpRequest httpRequest = new HttpRequest(Constants.QUEUES_URL_PARAM + queueName);
 
-        httpRequest.setQueryParameters("?ifUnused=" + String.valueOf(ifUnused) + "&ifEmpty=" + String.valueOf(ifEmpty));
+        httpRequest.setQueryParameters("?ifUnused=" + String.valueOf(!forceUsed)
+                                               + "&ifEmpty=" + String.valueOf(!forceNonEmpty));
 
         // do DELETE
         HttpResponse response = httpClient.sendHttpRequest(httpRequest, HTTP_DELETE);

--- a/modules/integration/src/test/java/io/ballerina/messaging/broker/integration/standalone/jms/DurableTopicMessagesOrderTest.java
+++ b/modules/integration/src/test/java/io/ballerina/messaging/broker/integration/standalone/jms/DurableTopicMessagesOrderTest.java
@@ -84,7 +84,7 @@ public class DurableTopicMessagesOrderTest {
         producerSession.close();
 
         for (int i = 0; i < numberOfMessages; i++) {
-            TextMessage message = (TextMessage) subscriber.receive(1000);
+            TextMessage message = (TextMessage) subscriber.receive(5000);
             Assert.assertNotNull(message, "Message #" + i + " was not received");
             subscriberOneMessages.add(message.getText());
         }
@@ -145,13 +145,13 @@ public class DurableTopicMessagesOrderTest {
         producerSession.close();
 
         for (int i = 0; i < numberOfMessages; i++) {
-            TextMessage message = (TextMessage) subscriberOne.receive(1000);
+            TextMessage message = (TextMessage) subscriberOne.receive(5000);
             Assert.assertNotNull(message, "Message #" + i + " was not received");
             subscriberOneMessages.add(message.getText());
         }
 
         for (int i = 0; i < numberOfMessages; i++) {
-            TextMessage message = (TextMessage) subscriberTwo.receive(1000);
+            TextMessage message = (TextMessage) subscriberTwo.receive(5000);
             Assert.assertNotNull(message, "Message #" + i + " was not received");
             subscriberTwoMessages.add(message.getText());
         }
@@ -217,7 +217,7 @@ public class DurableTopicMessagesOrderTest {
         Thread subscriberOneThread = new Thread(() -> {
             try {
                 for (int i = 0; i < numberOfMessages; i++) {
-                    TextMessage message = (TextMessage) subscriberOne.receive(1000);
+                    TextMessage message = (TextMessage) subscriberOne.receive(5000);
                     Assert.assertNotNull(message, "Message #" + i + " was not received");
                     subscriberOneMessages.add(message.getText());
                 }
@@ -231,7 +231,7 @@ public class DurableTopicMessagesOrderTest {
         Thread subscriberTwoThread = new Thread(() -> {
             try {
                 for (int i = 0; i < numberOfMessages; i++) {
-                    TextMessage message = (TextMessage) subscriberTwo.receive(1000);
+                    TextMessage message = (TextMessage) subscriberTwo.receive(5000);
                     Assert.assertNotNull(message, "Message #" + i + " was not received");
                     subscriberTwoMessages.add(message.getText());
                 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

- Set queues to be deleted only if the queue is empty and unused
- Set exchanges to be deleted only if it's unused

