### PR TITLE
Get connection/channel details through Consumer API

### DIFF
--- a/modules/broker-amqp/src/main/java/io/ballerina/messaging/broker/amqp/codec/AmqConstant.java
+++ b/modules/broker-amqp/src/main/java/io/ballerina/messaging/broker/amqp/codec/AmqConstant.java
@@ -25,6 +25,9 @@ package io.ballerina.messaging.broker.amqp.codec;
 public class AmqConstant {
     public static final int COMMAND_INVALID = 503;
 
+    public static final String TRANSPORT_PROPERTY_CHANNEL_ID = "channelId";
+    public static final String TRANSPORT_PROPERTY_CONNECTION_ID = "connectionId";
+
     private AmqConstant() {
     }
 }

--- a/modules/broker-amqp/src/main/java/io/ballerina/messaging/broker/amqp/codec/AmqpChannel.java
+++ b/modules/broker-amqp/src/main/java/io/ballerina/messaging/broker/amqp/codec/AmqpChannel.java
@@ -347,6 +347,10 @@ public class AmqpChannel {
         }
     }
 
+    public int getConnectionId() {
+        return connection.getId();
+    }
+
     public void setFlow(boolean active) {
         flow.set(active);
     }

--- a/modules/broker-amqp/src/main/java/io/ballerina/messaging/broker/amqp/consumer/AmqpConsumer.java
+++ b/modules/broker-amqp/src/main/java/io/ballerina/messaging/broker/amqp/consumer/AmqpConsumer.java
@@ -19,6 +19,7 @@
 
 package io.ballerina.messaging.broker.amqp.consumer;
 
+import io.ballerina.messaging.broker.amqp.codec.AmqConstant;
 import io.ballerina.messaging.broker.amqp.codec.AmqpChannel;
 import io.ballerina.messaging.broker.common.data.types.ShortString;
 import io.ballerina.messaging.broker.core.Broker;
@@ -29,6 +30,8 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
 
 /**
  * AMQP based message consumer.
@@ -55,6 +58,8 @@ public class AmqpConsumer extends Consumer {
 
     private boolean isReady;
 
+    private Properties transportProperties;
+
     public AmqpConsumer(ChannelHandlerContext ctx,
                         Broker broker,
                         AmqpChannel channel,
@@ -66,6 +71,7 @@ public class AmqpConsumer extends Consumer {
         this.isExclusive = isExclusive;
         this.context = ctx;
         this.channel = channel;
+        setTransportProperties();
         if (MessageTracer.isTraceEnabled()) {
             this.channelFutureListenerFactory = new ConsumerErrorHandlerFactory(broker, queueName);
         } else {
@@ -127,6 +133,17 @@ public class AmqpConsumer extends Consumer {
                 + ", consumerTag=" + consumerTag
                 + ", isExclusive=" + isExclusive
                 + '}';
+    }
+
+    private void setTransportProperties() {
+        Properties properties = new Properties();
+        properties.put(AmqConstant.TRANSPORT_PROPERTY_CHANNEL_ID, this.channel.getChannelId());
+        properties.put(AmqConstant.TRANSPORT_PROPERTY_CONNECTION_ID, this.channel.getConnectionId());
+        this.transportProperties = properties;
+    }
+
+    public Properties getTransportProperties() {
+        return transportProperties;
     }
 
 }

--- a/modules/broker-amqp/src/test/java/io/ballerina/messaging/broker/amqp/consumer/AmqpConsumerTest.java
+++ b/modules/broker-amqp/src/test/java/io/ballerina/messaging/broker/amqp/consumer/AmqpConsumerTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package io.ballerina.messaging.broker.amqp.consumer;
+
+import io.ballerina.messaging.broker.amqp.codec.AmqConstant;
+import io.ballerina.messaging.broker.amqp.codec.AmqpChannel;
+import io.ballerina.messaging.broker.common.data.types.ShortString;
+import io.ballerina.messaging.broker.core.Broker;
+import io.netty.channel.ChannelHandlerContext;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Properties;
+
+public class AmqpConsumerTest {
+
+    @Test
+    public void testGetTransportProperties() throws Exception {
+        AmqpChannel amqpChannel = Mockito.mock(AmqpChannel.class);
+        ChannelHandlerContext context = Mockito.mock(ChannelHandlerContext.class);
+        Broker broker = Mockito.mock(Broker.class);
+        Mockito.when(amqpChannel.getChannelId()).thenReturn(5);
+        Mockito.when(amqpChannel.getConnectionId()).thenReturn(7);
+        AmqpConsumer consumer = new AmqpConsumer(context, broker, amqpChannel, "queue",
+                                                 new ShortString(0, new byte[0]), true);
+        Properties transportProperties = consumer.getTransportProperties();
+        Assert.assertEquals(transportProperties.get(AmqConstant.TRANSPORT_PROPERTY_CHANNEL_ID), 5,
+                                                    "Incorrect channel id set");
+        Assert.assertEquals(transportProperties.get(AmqConstant.TRANSPORT_PROPERTY_CONNECTION_ID), 7,
+                                                    "Incorrect connection id set");
+    }
+
+}

--- a/modules/broker-core/src/gen/java/io/ballerina/messaging/broker/core/rest/model/ConsumerMetadata.java
+++ b/modules/broker-core/src/gen/java/io/ballerina/messaging/broker/core/rest/model/ConsumerMetadata.java
@@ -28,11 +28,12 @@ import java.util.Objects;
 
 
 public class ConsumerMetadata   {
-  
+
   private @Valid Integer id = null;
   private @Valid String consumerTag = null;
   private @Valid Boolean isExclusive = null;
   private @Valid Boolean flowEnabled = null;
+  private @Valid Object transportProperties = null;
 
   /**
    * unique id of the consumer
@@ -42,7 +43,7 @@ public class ConsumerMetadata   {
     return this;
   }
 
-  
+
   @ApiModelProperty(required = true, value = "unique id of the consumer")
   @JsonProperty("id")
   @NotNull
@@ -61,7 +62,7 @@ public class ConsumerMetadata   {
     return this;
   }
 
-  
+
   @ApiModelProperty(required = true, value = "identifier given by the channel")
   @JsonProperty("consumerTag")
   @NotNull
@@ -80,7 +81,7 @@ public class ConsumerMetadata   {
     return this;
   }
 
-  
+
   @ApiModelProperty(required = true, value = "State whether only this consumer can consume from the queue.")
   @JsonProperty("isExclusive")
   @NotNull
@@ -99,7 +100,7 @@ public class ConsumerMetadata   {
     return this;
   }
 
-  
+
   @ApiModelProperty(required = true, value = "State whether the consumers is actively consuming messages")
   @JsonProperty("flowEnabled")
   @NotNull
@@ -110,9 +111,27 @@ public class ConsumerMetadata   {
     this.flowEnabled = flowEnabled;
   }
 
+  /**
+   * Properties inherited by the underlying transport.
+   **/
+  public ConsumerMetadata transportProperties(Object transportProperties) {
+    this.transportProperties = transportProperties;
+    return this;
+  }
+
+
+  @ApiModelProperty(value = "Properties inherited by the underlying transport.")
+  @JsonProperty("transportProperties")
+  public Object getTransportProperties() {
+    return transportProperties;
+  }
+  public void setTransportProperties(Object transportProperties) {
+    this.transportProperties = transportProperties;
+  }
+
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -121,25 +140,27 @@ public class ConsumerMetadata   {
     }
     ConsumerMetadata consumerMetadata = (ConsumerMetadata) o;
     return Objects.equals(id, consumerMetadata.id) &&
-        Objects.equals(consumerTag, consumerMetadata.consumerTag) &&
-        Objects.equals(isExclusive, consumerMetadata.isExclusive) &&
-        Objects.equals(flowEnabled, consumerMetadata.flowEnabled);
+           Objects.equals(consumerTag, consumerMetadata.consumerTag) &&
+           Objects.equals(isExclusive, consumerMetadata.isExclusive) &&
+           Objects.equals(flowEnabled, consumerMetadata.flowEnabled) &&
+           Objects.equals(transportProperties, consumerMetadata.transportProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, consumerTag, isExclusive, flowEnabled);
+    return Objects.hash(id, consumerTag, isExclusive, flowEnabled, transportProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class ConsumerMetadata {\n");
-    
+
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    consumerTag: ").append(toIndentedString(consumerTag)).append("\n");
     sb.append("    isExclusive: ").append(toIndentedString(isExclusive)).append("\n");
     sb.append("    flowEnabled: ").append(toIndentedString(flowEnabled)).append("\n");
+    sb.append("    transportProperties: ").append(toIndentedString(transportProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -148,7 +169,7 @@ public class ConsumerMetadata   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/modules/broker-core/src/main/java/io/ballerina/messaging/broker/core/Consumer.java
+++ b/modules/broker-core/src/main/java/io/ballerina/messaging/broker/core/Consumer.java
@@ -19,6 +19,7 @@
 
 package io.ballerina.messaging.broker.core;
 
+import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -89,4 +90,6 @@ public abstract class Consumer {
     public int hashCode() {
         return Integer.hashCode(id);
     }
+
+    public abstract Properties getTransportProperties();
 }

--- a/modules/broker-core/src/main/java/io/ballerina/messaging/broker/core/rest/ConsumersApiDelegate.java
+++ b/modules/broker-core/src/main/java/io/ballerina/messaging/broker/core/rest/ConsumersApiDelegate.java
@@ -102,7 +102,8 @@ public class ConsumersApiDelegate {
         return new ConsumerMetadata()
                 .id(consumer.getId())
                 .isExclusive(consumer.isExclusive())
-                .flowEnabled(consumer.isReady());
+                .flowEnabled(consumer.isReady())
+                .transportProperties(consumer.getTransportProperties());
     }
 
     public Response deleteConsumer(String queueName, Integer consumerId, Subject subject) {

--- a/modules/broker-core/src/main/resources/swagger.yaml
+++ b/modules/broker-core/src/main/resources/swagger.yaml
@@ -948,6 +948,9 @@ definitions:
       flowEnabled:
         type: boolean
         description: State whether the consumers is actively consuming messages
+      transportProperties:
+        description: Properties inherited by the underlying transport.
+        type: object
   QueueCreateRequest:
     title: Queue Create Request
     type: object

--- a/modules/integration/src/test/java/io/ballerina/messaging/broker/integration/standalone/rest/ConsumersRestApiTest.java
+++ b/modules/integration/src/test/java/io/ballerina/messaging/broker/integration/standalone/rest/ConsumersRestApiTest.java
@@ -20,6 +20,7 @@
 package io.ballerina.messaging.broker.integration.standalone.rest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.ballerina.messaging.broker.amqp.codec.AmqConstant;
 import io.ballerina.messaging.broker.core.rest.QueuesApiDelegate;
 import io.ballerina.messaging.broker.core.rest.model.ConsumerMetadata;
 import io.ballerina.messaging.broker.core.rest.model.Error;
@@ -42,6 +43,7 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Map;
 import javax.jms.Queue;
 import javax.jms.QueueConnection;
 import javax.jms.QueueConnectionFactory;
@@ -115,6 +117,9 @@ public class ConsumersRestApiTest {
         String body = EntityUtils.toString(response.getEntity());
 
         ConsumerMetadata[] consumers = objectMapper.readValue(body, ConsumerMetadata[].class);
+        for (ConsumerMetadata consumerMetadata : consumers) {
+            validateTransportPropertyExistence(consumerMetadata);
+        }
 
         Assert.assertEquals(consumers.length, 2, "Number of consumers returned is incorrect.");
 
@@ -158,6 +163,7 @@ public class ConsumersRestApiTest {
         Assert.assertTrue(consumers.length > 0, "Number of consumers returned is incorrect.");
 
         int id = consumers[0].getId();
+        validateTransportPropertyExistence(consumers[0]);
         HttpGet getConsumer = new HttpGet(apiBasePath + QueuesApiDelegate.QUEUES_API_PATH + "/"
                                                   + queueName + "/consumers/" + id);
         ClientHelper.setAuthHeader(getConsumer, username, password);
@@ -243,5 +249,11 @@ public class ConsumersRestApiTest {
 
         Assert.assertFalse(error.getMessage().isEmpty(), "Error message shouldn't be empty.");
 
+    }
+
+    private void validateTransportPropertyExistence(ConsumerMetadata consumerMetadata) {
+        Map properties = (Map) consumerMetadata.getTransportProperties();
+        Assert.assertNotNull(properties.get(AmqConstant.TRANSPORT_PROPERTY_CHANNEL_ID));
+        Assert.assertNotNull(properties.get(AmqConstant.TRANSPORT_PROPERTY_CONNECTION_ID));
     }
 }


### PR DESCRIPTION
## Purpose
Modifies [ConsumerMetadata](https://github.com/ballerina-platform/ballerina-message-broker/blob/master/modules/broker-core/src/gen/java/io/ballerina/messaging/broker/core/rest/model/ConsumerMetadata.java) to display connection id and channel id

## Automation tests
 - Unit tests 
   - Code coverage - 77%
   - Introduced AmqpConsumerTest
