### PR TITLE
Introduce Channel and Connection close flags

### DIFF
--- a/modules/broker-amqp/src/gen/java/io/ballerina/messaging/broker/amqp/rest/api/ConnectionsApi.java
+++ b/modules/broker-amqp/src/gen/java/io/ballerina/messaging/broker/amqp/rest/api/ConnectionsApi.java
@@ -72,11 +72,13 @@ public class ConnectionsApi {
             @ApiResponse(code = 403, message = "User is not autherized to perform operation", response = Error.class),
             @ApiResponse(code = 404, message = "The specified resource was not found", response = Error.class)
     })
-    public Response closeConnection(@Context Request request, @PathParam("id") @ApiParam("Identifier of the "
-                                                                                        + "connection") Integer id,
-                                    @DefaultValue("false") @QueryParam("force")  @ApiParam("If set to true the broker"
-                                                                                           + " will close the underlying connection without trying to communicate with the connected AMQP client. If set to false, the broker will send a connection close frame to the client which will respond back with a connection close ok. Once this, frame is received, the connection will be closed.")  Boolean force) {
-        return connectionsApiDelegate.closeConnection(id, force, (Subject) request.getSession().getAttribute
+    public Response closeConnection(@Context Request request, @PathParam("id") @ApiParam("Identifier of the connection") Integer id,
+                                    @DefaultValue("false") @QueryParam("force") @ApiParam("If set to true the broker will close the underlying connection without trying to communicate with the connected AMQP client."
+                                                                                          + " If set to false, the broker will send a connection close frame to the client and the connection will be closed when the "
+                                                                                          + "client responds back with a connection close ok.")  Boolean force,
+                                    @DefaultValue("false") @QueryParam("used")  @ApiParam("If set to false, the broker will close the connection only if there are no AMQP channels registered on it. If set to true,"
+                                                                                            + " the connection will be closed regardless of the registered number of channels.")  Boolean used) {
+        return connectionsApiDelegate.closeConnection(id, force, used, (Subject) request.getSession().getAttribute
                 (BrokerAuthConstants.AUTHENTICATION_ID));
     }
 
@@ -110,8 +112,11 @@ public class ConnectionsApi {
     })
     public Response closeChannel(@Context Request request,
                                  @PathParam("connectionId") @ApiParam("Identifier of the connection") Integer connectionId,
-                                 @PathParam("channelId") @ApiParam("Identifier of the channel") Integer channelId) {
+                                 @PathParam("channelId") @ApiParam("Identifier of the channel") Integer channelId,
+                                 @DefaultValue("false")  @QueryParam("used")  @ApiParam("If set to false, the broker will close the channel only if there are no AMQP consumers for it. If set to true, "
+                                                                                          + "the channel will be closed regardless of the number of active consumers.")  Boolean used) {
         return connectionsApiDelegate.closeChannel(connectionId, channelId,
+                                                   used,
                                                    (Subject) request.getSession().getAttribute(BrokerAuthConstants.AUTHENTICATION_ID));
     }
 

--- a/modules/broker-amqp/src/main/resources/swagger.yaml
+++ b/modules/broker-amqp/src/main/resources/swagger.yaml
@@ -46,20 +46,29 @@ paths:
           type: integer
           required: true
           description: Identifier of the connection
-        - in: query
-          name: force
-          type: boolean
-          required: false
-          default: false
-          description: >-
-            If set to true the broker will close the underlying connection without trying to communicate with the
-            connected AMQP client. If set to false, the broker will send a connection close frame to the client and the
-            connection will be closed when the client responds back with a connection close ok.
       delete:
         operationId: closeConnection
         summary: Close the specified connection.
         description: >-
           Disconnects the specified amqp connection if the connection exists in the broker
+        parameters:
+          - in: query
+            name: force
+            type: boolean
+            required: false
+            default: false
+            description: >-
+              If set to true the broker will close the underlying connection without trying to communicate with the
+              connected AMQP client. If set to false, the broker will send a connection close frame to the client and the
+              connection will be closed when the client responds back with a connection close ok.
+          - in: query
+            name: used
+            type: boolean
+            required: false
+            default: false
+            description: >-
+              If set to false, the broker will close the connection only if there are no AMQP channels registered on
+              it. If set to true, the connection will be closed regardless of the registered number of channels.
         produces:
           - application/json
         responses:
@@ -82,16 +91,25 @@ paths:
         type: integer
         required: true
         description: Identifier of the connection
-      - in: path
-        name: channelId
-        type: integer
-        required: true
-        description: Identifier of the channel
     delete:
         operationId: closeChannel
         summary: Force disconnect the specified channel.
         description: >-
           Disconnects the specified amqp channel if an active channel exists in the broker
+        parameters:
+          - in: path
+            name: channelId
+            type: integer
+            required: true
+            description: Identifier of the channel
+          - in: query
+            name: used
+            type: boolean
+            required: false
+            default: false
+            description: >-
+              If set to false, the broker will close the channel only if there are no AMQP consumers for it. If set to
+              true, the channel will be closed regardless of the number of active consumers.
         produces:
           - application/json
         responses:

--- a/modules/broker-amqp/src/test/java/io/ballerina/messaging/broker/amqp/codec/handlers/AmqpConnectionHandlerTest.java
+++ b/modules/broker-amqp/src/test/java/io/ballerina/messaging/broker/amqp/codec/handlers/AmqpConnectionHandlerTest.java
@@ -1,0 +1,71 @@
+package io.ballerina.messaging.broker.amqp.codec.handlers;
+
+import io.ballerina.messaging.broker.amqp.AmqpConnectionManager;
+import io.ballerina.messaging.broker.amqp.codec.AmqpChannel;
+import io.ballerina.messaging.broker.amqp.codec.AmqpChannelFactory;
+import io.ballerina.messaging.broker.amqp.metrics.AmqpMetricManager;
+import io.ballerina.messaging.broker.common.ValidationException;
+import io.ballerina.messaging.broker.core.Broker;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class AmqpConnectionHandlerTest {
+
+    AmqpConnectionHandler connectionHandler;
+
+    AmqpChannel amqpChannel;
+
+    @BeforeMethod
+    public void setUp() {
+        Broker broker = Mockito.mock(Broker.class);
+        AmqpMetricManager metricManager = Mockito.mock(AmqpMetricManager.class);
+        Mockito.doNothing().when(metricManager).incrementChannelCount();
+        AmqpChannelFactory amqpChannelFactory = Mockito.mock(AmqpChannelFactory.class);
+        amqpChannel = Mockito.mock(AmqpChannel.class);
+        AmqpConnectionManager amqpConnectionManager = Mockito.mock(AmqpConnectionManager.class);
+        connectionHandler = new AmqpConnectionHandler(metricManager, amqpChannelFactory, amqpConnectionManager);
+        connectionHandler.attachBroker(broker);
+        Mockito.when(amqpChannelFactory.createChannel(broker, 1, connectionHandler)).thenReturn(amqpChannel);
+    }
+
+    @Test
+    public void testCloseConnection() throws Exception {
+
+        int channelCount = 5;
+        for (int i = 1; i <= channelCount; i++) {
+            connectionHandler.createChannel(i);
+        }
+
+        //test force=false, used=false
+        try {
+            connectionHandler.closeConnection("something", false, false);
+            Assert.fail("Expected ValidationException not thrown");
+        } catch (ValidationException e) {
+            Assert.assertEquals(e.getMessage(),
+                                "Cannot close connection. " + channelCount + " active channels exist and used "
+                                + "parameter is not set.");
+        }
+    }
+
+    @Test
+    public void testCloseChannel() throws Exception {
+
+        int channelId = 1;
+        int consumerCount = 5;
+        connectionHandler.createChannel(channelId);
+        Mockito.when(amqpChannel.getConsumerCount()).thenReturn(consumerCount);
+
+        //test force=false, used=false
+        try {
+            connectionHandler.closeChannel(channelId, false, "something");
+            Assert.fail("Expected ValidationException not thrown");
+        } catch (ValidationException e) {
+            Assert.assertEquals(e.getMessage(),
+                                "Cannot close channel. " + consumerCount + " active consumers exist and used "
+                                + "parameter is not set.");
+        }
+    }
+
+}

--- a/modules/broker-cli-client/src/main/java/io/ballerina/messaging/broker/client/cmd/impl/close/CloseChannelCmd.java
+++ b/modules/broker-cli-client/src/main/java/io/ballerina/messaging/broker/client/cmd/impl/close/CloseChannelCmd.java
@@ -36,6 +36,11 @@ public class CloseChannelCmd extends CloseCmd {
     @Parameter(description = "Identifier of the channel to be closed", required = true)
     private String channelId = "";
 
+    @Parameter(names = {Constants.IF_USED_FLAG},
+            description = "If set to true, the connection will be closed from the broker without "
+                          + "communicating with the amqp client")
+    private boolean ifUsed = false;
+
     public CloseChannelCmd(String rootCommand) {
         super(rootCommand);
     }
@@ -43,7 +48,7 @@ public class CloseChannelCmd extends CloseCmd {
     @Override
     public void execute() {
         executeClose(Constants.CONNECTIONS_URL_PARAM + connectionId + "/" + Constants.CHANNELS_URL_PARAM
-                     + channelId,
+                     + channelId + Constants.QUERY_PARAM_BEGINNING + Constants.USED_QUERY_PARAM + ifUsed,
                      "Channel close request submitted successfully");
     }
 

--- a/modules/broker-cli-client/src/main/java/io/ballerina/messaging/broker/client/cmd/impl/close/CloseConnectionCmd.java
+++ b/modules/broker-cli-client/src/main/java/io/ballerina/messaging/broker/client/cmd/impl/close/CloseConnectionCmd.java
@@ -37,13 +37,20 @@ public class CloseConnectionCmd extends CloseCmd {
                           + "communicating with the amqp client")
     private boolean force = false;
 
+    @Parameter(names = {Constants.IF_USED_FLAG},
+            description = "If set to true, the connection will be closed from the broker without "
+                          + "communicating with the amqp client")
+    private boolean ifUsed = false;
+
     public CloseConnectionCmd(String rootCommand) {
         super(rootCommand);
     }
 
     @Override
     public void execute() {
-        executeClose(Constants.CONNECTIONS_URL_PARAM + connectionId + Constants.FORCE_QUERY_PARAM + force,
+        executeClose(Constants.CONNECTIONS_URL_PARAM + connectionId + Constants.QUERY_PARAM_BEGINNING +
+                     Constants.FORCE_QUERY_PARAM + force + Constants.QUERY_PARAM_APPENDING + Constants
+                             .USED_QUERY_PARAM + ifUsed,
                      "Connection close request submitted successfully");
     }
 

--- a/modules/broker-cli-client/src/main/java/io/ballerina/messaging/broker/client/utils/Constants.java
+++ b/modules/broker-cli-client/src/main/java/io/ballerina/messaging/broker/client/utils/Constants.java
@@ -68,9 +68,13 @@ public class Constants {
     public static final String HTTP_DELETE = "DELETE";
 
     //http query parameters
-    public static final String FORCE_QUERY_PARAM = "?force=";
+    public static final String QUERY_PARAM_BEGINNING = "?";
+    public static final String QUERY_PARAM_APPENDING = "&";
+    public static final String FORCE_QUERY_PARAM = "force=";
+    public static final String USED_QUERY_PARAM = "used=";
 
     //flags
     public static final String HELP_FLAG = "--help";
+    public static final String IF_USED_FLAG = "--if-used";
     public static final String QUEUE_FLAG = "--queue";
 }

--- a/modules/integration/src/test/java/io/ballerina/messaging/broker/integration/standalone/cli/CloseCmdTest.java
+++ b/modules/integration/src/test/java/io/ballerina/messaging/broker/integration/standalone/cli/CloseCmdTest.java
@@ -123,7 +123,7 @@ public class CloseCmdTest extends CliTestParent {
         ConnectionMetadata[] connectionMetadataBeforeClosing = getConnections(username, password);
 
         String[] cmd = {CLI_ROOT_COMMAND, Constants.CMD_CLOSE, Constants.CMD_CHANNEL, "1", "--connection",
-                connectionMetadataBeforeClosing[0].getId().toString()};
+                connectionMetadataBeforeClosing[0].getId().toString(), Constants.IF_USED_FLAG};
         String expectedLog = "Request accepted for forceful disconnection of channel 1 of connection "
                              + connectionMetadataBeforeClosing[0].getId().toString();
 
@@ -180,13 +180,12 @@ public class CloseCmdTest extends CliTestParent {
 
         int channelCount = 3;
         //Create 3 connections each having 0, 1 and 2 channels respectively
-        List<Connection> connections = new ArrayList<>();
         connections.add(createConnection(channelCount, username, password, hostName, port));
 
         ConnectionMetadata[] connectionMetadataBeforeClosing = getConnections(username, password);
 
         String[] cmd = {CLI_ROOT_COMMAND, Constants.CMD_CLOSE, Constants.CMD_CONNECTION,
-                connectionMetadataBeforeClosing[0].getId().toString()};
+                connectionMetadataBeforeClosing[0].getId().toString(), Constants.IF_USED_FLAG};
         String expectedLog = "Connection close request submitted successfully";
 
         Main.main(cmd);
@@ -198,9 +197,6 @@ public class CloseCmdTest extends CliTestParent {
                                                                                       username, password);
         Assert.assertEquals(connectionMetadataAfterClosing.length, expectedConnectionCount,
                             "Incorrect connection count after closing connection.");
-
-
-        closeConnections(connections);
     }
 
     @Test(groups = "StreamReading", description = "test command 'close connection [connection-id]' with a "


### PR DESCRIPTION
## Purpose
Introduces the parameter 'ifUsed' for connection/channel close.

When a connection is closed using ifUsed, set to true, the connection is closed ignoring the active channels on it. if set to false, the connection wil be closed only if there are no active channels for it.

When a channel is closed using ifUsed, set to true, the channel is closed ignoring the active consumers on it. if set to false, the channel wil be closed only if there are no active consumers for it.
Resolves: https://github.com/ballerina-platform/ballerina-message-broker/issues/497, https://github.com/ballerina-platform/ballerina-message-broker/issues/499, https://github.com/ballerina-platform/ballerina-message-broker/issues/516

## Automation tests
  - Code coverage:78%
 - Integration tests
   - ConnectionsRestApiTest.testCloseConnectionsIfUsedFalse
   - ConnectionsRestApiTest.testCloseChannelsIfUsedFalse