### PR TITLE
Implement ldap authentication

### DIFF
--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/BrokerAuthConfiguration.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/BrokerAuthConfiguration.java
@@ -153,6 +153,8 @@ public class BrokerAuthConfiguration {
 
         private String className = DefaultAuthenticator.class.getCanonicalName();
 
+        private LdapConfiguration ldap = new LdapConfiguration();
+
         private Map<String, Object> properties = new HashMap<>();
 
         public String getClassName() {
@@ -161,6 +163,14 @@ public class BrokerAuthConfiguration {
 
         public void setClassName(String className) {
             this.className = className;
+        }
+
+        public LdapConfiguration getLdap() {
+            return ldap;
+        }
+
+        public void setLdap(LdapConfiguration ldap) {
+            this.ldap = ldap;
         }
 
         public Map<String, Object> getProperties() {
@@ -290,6 +300,170 @@ public class BrokerAuthConfiguration {
 
         public void setSize(int size) {
             this.size = size;
+        }
+    }
+
+    /**
+     * Represents Ldap configuration.
+     */
+    public static class LdapConfiguration {
+
+        private String hostName = "localhost";
+
+        private String baseDN = "dc=example,dc=com";
+
+        private String usernameSearchFilter = "(uid=?)";
+
+        private LdapPlainConfiguration plain = new LdapPlainConfiguration();
+
+        private LdapSslConfiguration ssl = new LdapSslConfiguration();
+
+        public String getHostName() {
+            return hostName;
+        }
+
+        public void setHostName(String hostName) {
+            this.hostName = hostName;
+        }
+
+        public String getBaseDN() {
+            return baseDN;
+        }
+
+        public void setBaseDN(String baseDN) {
+            this.baseDN = baseDN;
+        }
+
+        public String getUsernameSearchFilter() {
+            return usernameSearchFilter;
+        }
+
+        public void setUsernameSearchFilter(String usernameSearchFilter) {
+            this.usernameSearchFilter = usernameSearchFilter;
+        }
+
+        public LdapPlainConfiguration getPlain() {
+            return plain;
+        }
+
+        public void setPlain(LdapPlainConfiguration plain) {
+            this.plain = plain;
+        }
+
+        public LdapSslConfiguration getSsl() {
+            return ssl;
+        }
+
+        public void setSsl(LdapSslConfiguration ssl) {
+            this.ssl = ssl;
+        }
+    }
+
+    /**
+     * Represents Ldap configuration for plain connections (ssl disabled).
+     */
+    public static class LdapPlainConfiguration {
+
+        private int port = 10389;
+
+        public int getPort() {
+            return port;
+        }
+
+        public void setPort(int port) {
+            this.port = port;
+        }
+    }
+
+    /**
+     * Represents Ldap ssl configuration.
+     */
+    public static class LdapSslConfiguration {
+
+        private boolean enabled = false;
+
+        private int port = 10636;
+
+        private String protocol = "TLS";
+
+        private LdapSslTrustStoreConfiguration trustStore = new LdapSslTrustStoreConfiguration();
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+        public void setPort(int port) {
+            this.port = port;
+        }
+
+        public String getProtocol() {
+            return protocol;
+        }
+
+        public void setProtocol(String protocol) {
+            this.protocol = protocol;
+        }
+
+        public LdapSslTrustStoreConfiguration getTrustStore() {
+            return trustStore;
+        }
+
+        public void setTrustStore(LdapSslTrustStoreConfiguration trustStore) {
+            this.trustStore = trustStore;
+        }
+    }
+
+    /**
+     * Represents ssl trust store configuration for Ldap.
+     */
+    public static class LdapSslTrustStoreConfiguration {
+
+        private String type = "JKS";
+
+        private String location = "resources/security/ldap-truststore.jks";
+
+        private String password = "ballerina";
+
+        private String certType = "SunX509";
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public String getLocation() {
+            return location;
+        }
+
+        public void setLocation(String location) {
+            this.location = location;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public void setPassword(String password) {
+            this.password = password;
+        }
+
+        public String getCertType() {
+            return certType;
+        }
+
+        public void setCertType(String certType) {
+            this.certType = certType;
         }
     }
 }

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/authenticator/LdapAuthenticator.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/authenticator/LdapAuthenticator.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package io.ballerina.messaging.broker.auth.authentication.authenticator;
+
+import io.ballerina.messaging.broker.auth.AuthException;
+import io.ballerina.messaging.broker.auth.BrokerAuthConfiguration;
+import io.ballerina.messaging.broker.auth.authentication.AuthResult;
+import io.ballerina.messaging.broker.auth.authentication.Authenticator;
+import io.ballerina.messaging.broker.auth.authorization.UserStore;
+import io.ballerina.messaging.broker.auth.ldap.LdapAuthHandler;
+import io.ballerina.messaging.broker.common.StartupContext;
+import io.ballerina.messaging.broker.common.config.BrokerConfigProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import javax.naming.NamingException;
+import javax.naming.directory.DirContext;
+
+/**
+ * Ldap authentication representation for @{@link Authenticator}.
+ */
+public class LdapAuthenticator implements Authenticator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LdapAuthenticator.class);
+    private LdapAuthHandler ldapAuthHandler;
+
+    @Override
+    public void initialize(StartupContext startupContext,
+                           UserStore userStore,
+                           Map<String, Object> properties) throws Exception {
+
+        BrokerConfigProvider configProvider = startupContext.getService(BrokerConfigProvider.class);
+        BrokerAuthConfiguration brokerAuthConfiguration = configProvider.getConfigurationObject(
+                BrokerAuthConfiguration.NAMESPACE, BrokerAuthConfiguration.class);
+        BrokerAuthConfiguration.LdapConfiguration ldapConfiguration = brokerAuthConfiguration.getAuthentication()
+                .getAuthenticator().getLdap();
+
+        ldapAuthHandler = new LdapAuthHandler(ldapConfiguration);
+    }
+
+    @Override
+    public AuthResult authenticate(String username, char[] password) throws AuthException {
+
+        boolean isAuthenticated = false;
+
+        DirContext dirContext = null;
+        try {
+            dirContext = ldapAuthHandler.connectAnonymously();
+        } catch (NamingException e) {
+            throw new AuthException("Ldap connection failed", e);
+        }
+
+        String dn = null;
+        try {
+            dn = ldapAuthHandler.searchDN(dirContext, username);
+        } catch (NamingException e) {
+            throw new AuthException("Error while searching Username: " + username, e);
+        } finally {
+            if (dirContext != null) {
+                try {
+                    dirContext.close();
+                } catch (NamingException e) {
+                    LOGGER.debug("Error closing dir context", e);
+                }
+            }
+        }
+        try {
+            isAuthenticated = ldapAuthHandler.authenticate(dn, String.valueOf(password));
+        } catch (NamingException e) {
+            throw new AuthException("Error while authenticating Username: " + username, e);
+        }
+
+        return new AuthResult(isAuthenticated, username);
+    }
+}

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/ldap/LdapAuthHandler.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/ldap/LdapAuthHandler.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package io.ballerina.messaging.broker.auth.ldap;
+
+import io.ballerina.messaging.broker.auth.AuthException;
+import io.ballerina.messaging.broker.auth.BrokerAuthConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.util.Hashtable;
+import javax.naming.Context;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.InitialDirContext;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+/**
+ * Handles Ldap queries.
+ */
+public class LdapAuthHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LdapAuthHandler.class);
+    private BrokerAuthConfiguration.LdapConfiguration ldapConfiguration;
+
+    public LdapAuthHandler(BrokerAuthConfiguration.LdapConfiguration ldapConfiguration) throws AuthException {
+
+        this.ldapConfiguration = ldapConfiguration;
+        BrokerAuthConfiguration.LdapSslConfiguration sslConfig = ldapConfiguration.getSsl();
+
+        if (sslConfig.isEnabled()) {
+
+            String trustStoreLocation = Paths.get(sslConfig.getTrustStore().getLocation())
+                    .toAbsolutePath().toString();
+            try (FileInputStream fileInputStream = new FileInputStream(trustStoreLocation)) {
+
+                KeyStore trustStore = KeyStore.getInstance(sslConfig.getTrustStore().getType());
+                trustStore.load(fileInputStream, sslConfig.getTrustStore().getPassword().toCharArray());
+                TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
+                        sslConfig.getTrustStore().getCertType());
+                trustManagerFactory.init(trustStore);
+                SSLContext sslContext = SSLContext.getInstance(sslConfig.getProtocol());
+                sslContext.init(null, trustManagerFactory.getTrustManagers(), null);
+                LdapSslSocketFactory.setSslContext(sslContext);
+
+            } catch (KeyStoreException | IOException | NoSuchAlgorithmException | CertificateException
+                    | KeyManagementException e) {
+                throw new AuthException("Initializing ldap trust store failed", e);
+            }
+        }
+    }
+
+    public DirContext connectAnonymously() throws NamingException {
+
+        return connect(new Hashtable<>());
+    }
+
+    /**
+     * Connect to ldap server.
+     *
+     * @param env properties to be passed to InitialDirContext
+     * @return InitialDirContext if the connection is successful
+     * @throws NamingException if the connection failed
+     */
+    private DirContext connect(Hashtable<String, String> env) throws NamingException {
+
+        DirContext dirContext = null;
+        env.put(Context.INITIAL_CONTEXT_FACTORY, LdapConstants.JNDI_LDAP_CTX_FACTORY);
+        env.put(Context.SECURITY_AUTHENTICATION, LdapConstants.LDAP_AUTHENTICATION_SIMPLE);
+
+        if (ldapConfiguration.getSsl().isEnabled()) {
+
+            env.put(Context.PROVIDER_URL,
+                    "ldap://" + ldapConfiguration.getHostName() + ":" + ldapConfiguration.getSsl().getPort());
+            env.put(Context.SECURITY_PROTOCOL, LdapConstants.SECURITY_PROTOCOL_SSL);
+            env.put(LdapConstants.ENV_KEY_LDAP_SOCKET_FACTORY, LdapSslSocketFactory.class.getName());
+            dirContext = new InitialDirContext(env);
+
+        } else {
+
+            env.put(Context.PROVIDER_URL,
+                    "ldap://" + ldapConfiguration.getHostName() + ":" + ldapConfiguration.getPlain().getPort());
+            dirContext = new InitialDirContext(env);
+        }
+
+        return dirContext;
+    }
+
+    /**
+     * Fetch distinguished name (dn) of the given user.
+     *
+     * @param dirContext ldap connection object
+     * @param username of the user
+     * @return distinguished name (dn) of the given user. Null if not found.
+     * @throws NamingException in case of an erroneous search query
+     */
+    public String searchDN(DirContext dirContext, String username) throws NamingException {
+
+        String lookup = ldapConfiguration.getUsernameSearchFilter().replace("?", username);
+        SearchControls searchControls = new SearchControls();
+        searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+
+        NamingEnumeration<SearchResult> answer
+                = dirContext.search(ldapConfiguration.getBaseDN(), lookup, searchControls);
+
+        String dn;
+        if (answer.hasMore()) {
+            javax.naming.directory.SearchResult result = answer.next();
+            dn = result.getNameInNamespace();
+            LOGGER.debug("DN: {} obtained for Username: {}", dn, username);
+        } else {
+            dn = null;
+            LOGGER.debug("DN search failed for Username: {}", username);
+        }
+        answer.close();
+        return dn;
+    }
+
+    /**
+     * Authenticate the user's distinguished name and password.
+     *
+     * @param dn distinguished name of the user
+     * @param password of the user
+     * @return whether authenticated or not
+     * @throws NamingException if the connection failed
+     */
+    public boolean authenticate(String dn, String password) throws NamingException {
+
+        boolean isAuthenticated = false;
+
+        if (dn != null && dn.length() > 0) {
+
+            Hashtable<String, String> env = new Hashtable<>();
+            env.put(Context.SECURITY_PRINCIPAL, dn);
+            env.put(Context.SECURITY_CREDENTIALS, String.valueOf(password));
+            DirContext authDirContext = null;
+            try {
+                authDirContext = connect(env);
+                isAuthenticated = true;
+                LOGGER.debug("DN: {} authenticated successfully", dn);
+            } catch (javax.naming.AuthenticationException e) {
+                LOGGER.debug("DN: {} authentication failed", dn, e);
+            } finally {
+                if (authDirContext != null) {
+                    try {
+                        authDirContext.close();
+                    } catch (NamingException e) {
+                        LOGGER.debug("Error closing dir context", e);
+                    }
+                }
+            }
+        } else {
+            LOGGER.debug("Invalid DN");
+        }
+
+        return isAuthenticated;
+    }
+}

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/ldap/LdapConstants.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/ldap/LdapConstants.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package io.ballerina.messaging.broker.auth.ldap;
+
+/**
+ * Constants related to ldap authentication/authorization.
+ */
+public class LdapConstants {
+
+    private LdapConstants() {
+    }
+
+    public static final String JNDI_LDAP_CTX_FACTORY = "com.sun.jndi.ldap.LdapCtxFactory";
+    public static final String LDAP_AUTHENTICATION_SIMPLE = "simple";
+    public static final String ENV_KEY_LDAP_SOCKET_FACTORY = "java.naming.ldap.factory.socket";
+    public static final String SECURITY_PROTOCOL_SSL = "ssl";
+
+}

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/ldap/LdapSslSocketFactory.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/ldap/LdapSslSocketFactory.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package io.ballerina.messaging.broker.auth.ldap;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * Wrapper for @{@link SSLSocketFactory}.
+ * Because JNDI instantiate the socket factory internally, a wrapper class is required to provide
+ * a SSLContext with a custom Trust Store.
+ */
+public class LdapSslSocketFactory extends SSLSocketFactory {
+
+    private static SSLContext sslContext;
+    private SSLSocketFactory sslSocketFactory;
+
+    public static void setSslContext(SSLContext sslContext) {
+        LdapSslSocketFactory.sslContext = sslContext;
+    }
+
+    public static SSLContext getSslContext() {
+        return sslContext;
+    }
+
+    public LdapSslSocketFactory() {
+        sslSocketFactory = sslContext.getSocketFactory();
+    }
+
+    public static SocketFactory getDefault() {
+        return new LdapSslSocketFactory();
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return sslSocketFactory.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return sslSocketFactory.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket(Socket socket, String host, int port, boolean autoClose) throws IOException {
+        return sslSocketFactory.createSocket(socket, host, port, autoClose);
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+        return sslSocketFactory.createSocket(host, port);
+    }
+
+    @Override
+    public Socket createSocket(String host, int port,
+                               InetAddress clientAddress, int clientPort) throws IOException, UnknownHostException {
+        return sslSocketFactory.createSocket(host, port, clientAddress, clientPort);
+    }
+
+    @Override
+    public Socket createSocket(InetAddress inetAddress, int port) throws IOException {
+        return sslSocketFactory.createSocket(inetAddress, port);
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port,
+                               InetAddress clientAddress, int clientPort) throws IOException {
+        return sslSocketFactory.createSocket(address, port, clientAddress, clientPort);
+    }
+}


### PR DESCRIPTION
This update provides the ability to use a Ldap server for authentication.
Configurations are provided through the broker.yaml file.

Todo:
Test cases and documentation of configuration details

Issue:
[Implement user authentication using an LDAP server](https://github.com/ballerina-platform/ballerina-message-broker/issues/505)
