### PR TITLE
Implement ldap authorization functionality

### DIFF
--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/BrokerAuthConfiguration.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/BrokerAuthConfiguration.java
@@ -189,6 +189,8 @@ public class BrokerAuthConfiguration {
 
         private String className = FileBasedUserStore.class.getCanonicalName();
 
+        private LdapConfiguration ldap = new LdapConfiguration();
+
         private Map<String, String> properties = new HashMap<>();
 
         public String getClassName() {
@@ -197,6 +199,14 @@ public class BrokerAuthConfiguration {
 
         public void setClassName(String className) {
             this.className = className;
+        }
+
+        public LdapConfiguration getLdap() {
+            return ldap;
+        }
+
+        public void setLdap(LdapConfiguration ldap) {
+            this.ldap = ldap;
         }
 
         public Map<String, String> getProperties() {
@@ -314,6 +324,12 @@ public class BrokerAuthConfiguration {
 
         private String usernameSearchFilter = "(uid=?)";
 
+        private String groupBaseDN = "dc=example,dc=com";
+
+        private String groupMembershipFilter = "(&(objectClass=groupOfNames)(member=?))";
+
+        private String groupNameAttribute = "cn";
+
         private LdapPlainConfiguration plain = new LdapPlainConfiguration();
 
         private LdapSslConfiguration ssl = new LdapSslConfiguration();
@@ -340,6 +356,30 @@ public class BrokerAuthConfiguration {
 
         public void setUsernameSearchFilter(String usernameSearchFilter) {
             this.usernameSearchFilter = usernameSearchFilter;
+        }
+
+        public String getGroupBaseDN() {
+            return groupBaseDN;
+        }
+
+        public void setGroupBaseDN(String groupBaseDN) {
+            this.groupBaseDN = groupBaseDN;
+        }
+
+        public String getGroupMembershipFilter() {
+            return groupMembershipFilter;
+        }
+
+        public void setGroupMembershipFilter(String groupMembershipFilter) {
+            this.groupMembershipFilter = groupMembershipFilter;
+        }
+
+        public String getGroupNameAttribute() {
+            return groupNameAttribute;
+        }
+
+        public void setGroupNameAttribute(String groupNameAttribute) {
+            this.groupNameAttribute = groupNameAttribute;
         }
 
         public LdapPlainConfiguration getPlain() {

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/authenticator/LdapAuthenticator.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/authenticator/LdapAuthenticator.java
@@ -26,19 +26,15 @@ import io.ballerina.messaging.broker.auth.authorization.UserStore;
 import io.ballerina.messaging.broker.auth.ldap.LdapAuthHandler;
 import io.ballerina.messaging.broker.common.StartupContext;
 import io.ballerina.messaging.broker.common.config.BrokerConfigProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import javax.naming.NamingException;
-import javax.naming.directory.DirContext;
 
 /**
  * Ldap authentication representation for @{@link Authenticator}.
  */
 public class LdapAuthenticator implements Authenticator {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(LdapAuthenticator.class);
     private LdapAuthHandler ldapAuthHandler;
 
     @Override
@@ -58,28 +54,12 @@ public class LdapAuthenticator implements Authenticator {
     @Override
     public AuthResult authenticate(String username, char[] password) throws AuthException {
 
-        boolean isAuthenticated = false;
-
-        DirContext dirContext = null;
+        boolean isAuthenticated;
+        String dn;
         try {
-            dirContext = ldapAuthHandler.connectAnonymously();
-        } catch (NamingException e) {
-            throw new AuthException("Ldap connection failed", e);
-        }
-
-        String dn = null;
-        try {
-            dn = ldapAuthHandler.searchDN(dirContext, username);
+            dn = ldapAuthHandler.searchDN(username);
         } catch (NamingException e) {
             throw new AuthException("Error while searching Username: " + username, e);
-        } finally {
-            if (dirContext != null) {
-                try {
-                    dirContext.close();
-                } catch (NamingException e) {
-                    LOGGER.debug("Error closing dir context", e);
-                }
-            }
         }
         try {
             isAuthenticated = ldapAuthHandler.authenticate(dn, String.valueOf(password));

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authorization/UserStore.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authorization/UserStore.java
@@ -63,5 +63,5 @@ public interface UserStore {
      * @param username username to verify
      * @return true or false based on the verification
      */
-    boolean isUserExists(String username);
+    boolean isUserExists(String username) throws AuthException;
 }

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authorization/provider/LdapUserStore.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authorization/provider/LdapUserStore.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package io.ballerina.messaging.broker.auth.authorization.provider;
+
+import io.ballerina.messaging.broker.auth.AuthException;
+import io.ballerina.messaging.broker.auth.BrokerAuthConfiguration;
+import io.ballerina.messaging.broker.auth.authentication.AuthResult;
+import io.ballerina.messaging.broker.auth.authorization.UserStore;
+import io.ballerina.messaging.broker.auth.ldap.LdapAuthHandler;
+import io.ballerina.messaging.broker.common.StartupContext;
+import io.ballerina.messaging.broker.common.config.BrokerConfigProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import javax.naming.NamingException;
+import javax.naming.directory.DirContext;
+
+/**
+ * This class implements @{@link UserStore} to provide a ldap based user store.
+ */
+public class LdapUserStore implements UserStore {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LdapUserStore.class);
+    private LdapAuthHandler ldapAuthHandler;
+
+    @Override
+    public void initialize(StartupContext startupContext, Map<String, String> properties) throws Exception {
+
+        BrokerConfigProvider configProvider = startupContext.getService(BrokerConfigProvider.class);
+        BrokerAuthConfiguration brokerAuthConfiguration = configProvider.getConfigurationObject(
+                BrokerAuthConfiguration.NAMESPACE, BrokerAuthConfiguration.class);
+        BrokerAuthConfiguration.LdapConfiguration ldapConfiguration = brokerAuthConfiguration.getAuthorization()
+                .getUserStore().getLdap();
+
+        ldapAuthHandler = new LdapAuthHandler(ldapConfiguration);
+    }
+
+    @Override
+    public AuthResult authenticate(String username, char... credentials) throws AuthException {
+        throw new AuthException("Not implemented"); //this functionality will be removed from the user store interface
+    }
+
+    @Override
+    public boolean isUserExists(String username) throws AuthException {
+
+        boolean exists = false;
+        DirContext dirContext = null;
+        try {
+            dirContext = ldapAuthHandler.connectAnonymously();
+        } catch (NamingException e) {
+            throw new AuthException("Ldap connection failed", e);
+        }
+
+        try {
+            if (Objects.nonNull(ldapAuthHandler.searchDN(dirContext, username))) {
+                exists = true;
+            }
+        } catch (NamingException e) {
+            throw new AuthException("Error while searching Username: " + username, e);
+        } finally {
+            if (dirContext != null) {
+                try {
+                    dirContext.close();
+                } catch (NamingException e) {
+                    LOGGER.debug("Error closing dir context", e);
+                }
+            }
+        }
+
+        return exists;
+    }
+
+    @Override
+    public Set<String> getUserGroupsList(String username) throws AuthException {
+
+        DirContext dirContext = null;
+        try {
+            dirContext = ldapAuthHandler.connectAnonymously();
+        } catch (NamingException e) {
+            throw new AuthException("Ldap connection failed", e);
+        }
+
+        String dn = null;
+        try {
+            dn = ldapAuthHandler.searchDN(dirContext, username);
+        } catch (NamingException e) {
+            throw new AuthException("Error while searching Username: " + username, e);
+        }
+        try {
+            return ldapAuthHandler.getUserGroups(dirContext, dn);
+        } catch (NamingException e) {
+            throw new AuthException("Error while fetching groups for Username: " + username, e);
+        } finally {
+            if (dirContext != null) {
+                try {
+                    dirContext.close();
+                } catch (NamingException e) {
+                    LOGGER.debug("Error closing dir context", e);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This update provides the ability to use a Ldap server for fetching groups a certain user belongs to.
Configurations are provided through the broker.yaml file.

Todo:
- Test cases
- Documentation of configs
- Use an in-memory cache to reduce number of queries to ldap server